### PR TITLE
Scaffold Next.js workspace for thinking chat app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+.data
+.env*
+*.log
+data/app.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-用nodejs或php或python做一个网站，你认为哪个更好？实现调用api对话，完美支持openai/newapi端点，包括completion的端点，可以自定义url,使用sqlite数据库。对话实现基本要求与nextchat或lobechat一样，有相应功能，包括但不小于获取模型列表，输入自定义模型，选择模型，重生响应，暂停响应，对话列表，历史，上下文，图片标题等。但是额外支持一些非思考模型思考，具体大致实现逻辑为勾选此功能后要求选择两个模型，一个是思考模型，预置思考的系统提示词，要求思考，但不给出结果，一个是回答模型然后将问题和思考结果一并返回给回答模型要求提供结果。两个模型可以一样可以不一样。
+# Thinking Chat
+
+A Next.js + TypeScript starter implementing the foundations for a multi-model chat client inspired by NextChat/LobeChat with an optional thinking pipeline.
+
+## Features
+
+- Server components backed by SQLite (via `better-sqlite3`) with tables for models, conversations, messages, and thinking runs.
+- API routes for managing models, conversations, settings, and orchestrating thinking + answering model flows.
+- React client workspace with sidebar, message viewer, composer, and thinking trace preview.
+- Extensible architecture for OpenAI-compatible endpoints with customizable base URLs and API keys.
+
+## Getting Started
+
+1. Install dependencies
+
+   ```bash
+   pnpm install
+   ```
+
+2. Run database migrations (tables are created automatically on first run).
+
+3. Start the development server
+
+   ```bash
+   pnpm dev
+   ```
+
+4. Open `http://localhost:3000` to explore the landing page or `http://localhost:3000/workspace` for the chat workspace preview.
+
+## Next Steps
+
+- Wire `fetchChatCompletion` to real OpenAI/newapi endpoints with streaming support.
+- Implement pause/resume, regenerate, image captioning, and settings UI.
+- Add authentication and encryption for sensitive settings if needed.
+- Expand test coverage and add CI workflows.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { orchestrateChat } from "@/server/orchestrator";
+
+const messageSchema = z.object({
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  content: z.string(),
+});
+
+const requestSchema = z.object({
+  conversationId: z.string().optional(),
+  messages: z.array(messageSchema),
+  settings: z.object({
+    baseUrl: z.string().url().optional(),
+    apiKey: z.string().optional(),
+    thinking: z
+      .object({
+        enabled: z.boolean(),
+        thinkingModel: z.string(),
+        answerModel: z.string(),
+        systemPrompt: z.string().optional(),
+      })
+      .optional(),
+    model: z.string(),
+  }),
+});
+
+export async function POST(request: NextRequest) {
+  const json = await request.json();
+  const body = requestSchema.parse(json);
+  const result = await orchestrateChat(body);
+  return Response.json(result);
+}

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { getDatabase } from "@/lib/database";
+
+const createConversationSchema = z.object({
+  title: z.string().min(1),
+  modelId: z.string().min(1),
+});
+
+export async function GET() {
+  const db = await getDatabase();
+  const conversations = db.listConversations();
+  return Response.json({ conversations });
+}
+
+export async function POST(request: NextRequest) {
+  const json = await request.json();
+  const body = createConversationSchema.parse(json);
+  const db = await getDatabase();
+  const id = db.createConversation(body.title, body.modelId);
+  const conversations = db.listConversations();
+  return Response.json({ id, conversations }, { status: 201 });
+}

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+import { getModelStore } from "@/lib/model-store";
+import { getDatabase } from "@/lib/database";
+import { z } from "zod";
+
+const addModelSchema = z.object({
+  id: z.string().min(1),
+  displayName: z.string().min(1),
+  provider: z.string().default("custom"),
+});
+
+export async function GET() {
+  const store = await getModelStore();
+  const models = store.listModels();
+  return Response.json({ models });
+}
+
+export async function POST(request: NextRequest) {
+  const json = await request.json();
+  const body = addModelSchema.parse(json);
+  const db = await getDatabase();
+  db.upsertModel(body.id, body.displayName, body.provider);
+  const store = await getModelStore();
+  return Response.json({ models: store.listModels() }, { status: 201 });
+}

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+
+const settingsSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  apiKey: z.string().optional(),
+  model: z.string().optional(),
+  thinkingPrompt: z.string().optional(),
+});
+
+const COOKIE_NAME = "thinking-chat-settings";
+
+export async function GET() {
+  const store = cookies();
+  const raw = store.get(COOKIE_NAME)?.value;
+  const settings = raw ? JSON.parse(raw) : {};
+  return Response.json({ settings });
+}
+
+export async function POST(request: NextRequest) {
+  const json = await request.json();
+  const body = settingsSchema.parse(json);
+  cookies().set({
+    name: COOKIE_NAME,
+    value: JSON.stringify(body),
+    httpOnly: false,
+    sameSite: "lax",
+  });
+  return Response.json({ settings: body }, { status: 201 });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+}
+
+.dark {
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 212.7 26.8% 83.9%;
+}
+
+body {
+  min-height: 100vh;
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,23 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import { ReactNode } from "react";
+import { Providers } from "@/src/state/providers";
+
+export const metadata: Metadata = {
+  title: "Thinking Chat",
+  description: "Multi-model chat client with thinking pipeline",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-10">
+      <header className="space-y-2 text-center">
+        <h1 className="text-3xl font-bold">Thinking Chat</h1>
+        <p className="text-muted-foreground">
+          A Next.js starter for a multi-model chat client with optional thinking
+          pipeline.
+        </p>
+      </header>
+
+      <section className="rounded-lg border p-6">
+        <h2 className="text-xl font-semibold">Getting Started</h2>
+        <ol className="mt-4 list-decimal space-y-2 pl-4 text-left">
+          <li>Configure your API key and base URL in the Settings panel.</li>
+          <li>
+            Create a conversation from the sidebar and pick your primary model.
+          </li>
+          <li>
+            (Optional) Enable the thinking pipeline by choosing a thinking model
+            and answer model.
+          </li>
+        </ol>
+        <p className="mt-4 text-sm text-muted-foreground">
+          The full chat workspace is under construction. Visit the
+          <Link className="ml-1 text-blue-600 underline" href="/workspace">
+            workspace preview
+          </Link>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from "react";
+import { WorkspaceShell } from "@/components/workspace-shell";
+import { fetchInitialWorkspaceData } from "@/server/workspace-data";
+
+export default async function WorkspacePage() {
+  const data = await fetchInitialWorkspaceData();
+
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading workspace…</div>}>
+      <WorkspaceShell initialData={data} />
+    </Suspense>
+  );
+}

--- a/components/workspace-shell.tsx
+++ b/components/workspace-shell.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ConversationList } from "@/components/workspace/sidebar";
+import { ChatComposer } from "@/components/workspace/composer";
+import { MessageList } from "@/components/workspace/messages";
+import type { InitialWorkspaceData } from "@/server/workspace-data";
+
+export function WorkspaceShell({
+  initialData,
+}: {
+  initialData: InitialWorkspaceData;
+}) {
+  const [activeConversationId, setActiveConversationId] = useState(
+    initialData.conversations[0]?.id ?? null,
+  );
+
+  const activeConversation = useMemo(
+    () =>
+      initialData.conversations.find((item) => item.id === activeConversationId) ??
+      null,
+    [activeConversationId, initialData.conversations],
+  );
+
+  return (
+    <div className="grid min-h-screen grid-cols-[280px_1fr]">
+      <aside className="border-r">
+        <ConversationList
+          conversations={initialData.conversations}
+          activeId={activeConversationId}
+          onSelect={setActiveConversationId}
+        />
+      </aside>
+      <main className="flex flex-col">
+        <MessageList
+          messages={activeConversation?.messages ?? []}
+          thinkingRuns={initialData.thinkingRuns[activeConversationId ?? ""] ?? []}
+        />
+        <ChatComposer
+          models={initialData.models}
+          activeConversationId={activeConversationId}
+        />
+      </main>
+    </div>
+  );
+}

--- a/components/workspace/composer.tsx
+++ b/components/workspace/composer.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import type { WorkspaceModel } from "@/server/workspace-data";
+
+export function ChatComposer({
+  models,
+  activeConversationId,
+}: {
+  models: WorkspaceModel[];
+  activeConversationId: string | null;
+}) {
+  const [message, setMessage] = useState("");
+  const [thinkingEnabled, setThinkingEnabled] = useState(false);
+  const [thinkingModel, setThinkingModel] = useState<string>(models[0]?.id ?? "");
+  const [answerModel, setAnswerModel] = useState<string>(models[0]?.id ?? "");
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // TODO: hook up to API mutation
+    setMessage("");
+    console.info("Submit", {
+      message,
+      activeConversationId,
+      thinkingEnabled,
+      thinkingModel,
+      answerModel,
+    });
+  };
+
+  return (
+    <form className="border-t p-4" onSubmit={handleSubmit}>
+      <div className="flex flex-col gap-3">
+        <textarea
+          className="min-h-[120px] w-full rounded border p-3 text-sm"
+          placeholder="Ask anything..."
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+        />
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={thinkingEnabled}
+              onChange={(event) => setThinkingEnabled(event.target.checked)}
+            />
+            Enable thinking pipeline
+          </label>
+          {thinkingEnabled && (
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                className="rounded border px-2 py-1"
+                value={thinkingModel}
+                onChange={(event) => setThinkingModel(event.target.value)}
+              >
+                {models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.displayName}
+                  </option>
+                ))}
+              </select>
+              <span>→</span>
+              <select
+                className="rounded border px-2 py-1"
+                value={answerModel}
+                onChange={(event) => setAnswerModel(event.target.value)}
+              >
+                {models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.displayName}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="text-xs text-muted-foreground">
+            Conversation: {activeConversationId ?? "New"}
+          </div>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white"
+            disabled={!message.trim()}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/components/workspace/messages.tsx
+++ b/components/workspace/messages.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type {
+  WorkspaceMessage,
+  WorkspaceThinkingRun,
+} from "@/server/workspace-data";
+
+export function MessageList({
+  messages,
+  thinkingRuns,
+}: {
+  messages: WorkspaceMessage[];
+  thinkingRuns: WorkspaceThinkingRun[];
+}) {
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4">
+        {messages.map((message) => (
+          <article key={message.id} className="rounded border p-4">
+            <header className="mb-2 flex items-center justify-between text-xs uppercase text-muted-foreground">
+              <span>{message.role}</span>
+              <span>{message.createdAt}</span>
+            </header>
+            <p className="whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+          </article>
+        ))}
+        {thinkingRuns.length > 0 && (
+          <section className="rounded border border-dashed p-4 text-xs text-muted-foreground">
+            <h3 className="mb-2 font-semibold uppercase">Thinking Trace</h3>
+            <ol className="space-y-3">
+              {thinkingRuns.map((run) => (
+                <li key={run.id}>
+                  <div className="font-medium">{run.modelId}</div>
+                  <pre className="mt-1 whitespace-pre-wrap rounded bg-muted p-2 text-[11px] leading-5">
+                    {run.output}
+                  </pre>
+                </li>
+              ))}
+            </ol>
+          </section>
+        )}
+        {messages.length === 0 && (
+          <div className="rounded border border-dashed p-10 text-center text-sm text-muted-foreground">
+            Start the conversation by sending a message.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/workspace/sidebar.tsx
+++ b/components/workspace/sidebar.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import classNames from "classnames";
+import { useMemo } from "react";
+import type { WorkspaceConversation } from "@/server/workspace-data";
+
+export function ConversationList({
+  conversations,
+  activeId,
+  onSelect,
+}: {
+  conversations: WorkspaceConversation[];
+  activeId: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  const items = useMemo(() => conversations, [conversations]);
+
+  return (
+    <div className="flex h-full flex-col gap-2 p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+          Conversations
+        </h2>
+        <button
+          type="button"
+          className="rounded border px-2 py-1 text-xs"
+          onClick={() => onSelect(items[0]?.id ?? null)}
+        >
+          Refresh
+        </button>
+      </div>
+      <div className="flex-1 space-y-1 overflow-y-auto">
+        {items.map((conversation) => (
+          <button
+            key={conversation.id}
+            type="button"
+            className={classNames(
+              "w-full rounded px-3 py-2 text-left text-sm transition",
+              activeId === conversation.id
+                ? "bg-blue-500 text-white"
+                : "hover:bg-muted",
+            )}
+            onClick={() => onSelect(conversation.id)}
+          >
+            <div className="font-medium">{conversation.title}</div>
+            <div className="text-xs text-muted-foreground">
+              {conversation.modelLabel}
+            </div>
+          </button>
+        ))}
+        {items.length === 0 && (
+          <div className="rounded border border-dashed p-3 text-xs text-muted-foreground">
+            No conversations yet. Create one from the composer.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,0 +1,224 @@
+import Database from "better-sqlite3";
+import path from "path";
+import fs from "fs";
+import { randomUUID } from "crypto";
+import type {
+  WorkspaceConversation,
+  WorkspaceMessage,
+  WorkspaceThinkingRun,
+  WorkspaceModel,
+} from "@/server/workspace-data";
+
+const dbFile = path.join(process.cwd(), "data", "app.db");
+
+let client: Database.Database | null = null;
+
+function ensureClient(): Database.Database {
+  if (!client) {
+    const directory = path.dirname(dbFile);
+    ensureDirectory(directory);
+    client = new Database(dbFile);
+    client.pragma("journal_mode = WAL");
+    bootstrap(client);
+  }
+  return client;
+}
+
+function bootstrap(db: Database.Database) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS models (
+      id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      provider TEXT NOT NULL DEFAULT 'custom',
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS conversations (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS thinking_runs (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      output TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+}
+
+export async function getDatabase() {
+  const db = ensureClient();
+  return {
+    listModels(): WorkspaceModel[] {
+      return db
+        .prepare(
+          `SELECT id, display_name as displayName, provider, updated_at as updatedAt FROM models ORDER BY updated_at DESC`,
+        )
+        .all() as WorkspaceModel[];
+    },
+    listConversations(): WorkspaceConversation[] {
+      const conversations = db
+        .prepare(
+          `SELECT id, title, model_id, created_at, updated_at FROM conversations ORDER BY updated_at DESC`,
+        )
+        .all() as Array<{
+        id: string;
+        title: string;
+        model_id: string;
+        created_at: string;
+        updated_at: string;
+      }>;
+
+      return conversations.map((conversation) => ({
+        id: conversation.id,
+        title: conversation.title,
+        modelId: conversation.model_id,
+        modelLabel: conversation.model_id,
+        createdAt: conversation.created_at,
+        updatedAt: conversation.updated_at,
+        messages: listMessages(conversation.id),
+      }));
+    },
+    listThinkingRuns(): Record<string, WorkspaceThinkingRun[]> {
+      const rows = db
+        .prepare(
+          `SELECT id, conversation_id, model_id, output, created_at FROM thinking_runs ORDER BY created_at ASC`,
+        )
+        .all() as Array<{
+        id: string;
+        conversation_id: string;
+        model_id: string;
+        output: string;
+        created_at: string;
+      }>;
+
+      return rows.reduce<Record<string, WorkspaceThinkingRun[]>>((acc, row) => {
+        if (!acc[row.conversation_id]) {
+          acc[row.conversation_id] = [];
+        }
+        const entry: WorkspaceThinkingRun = {
+          id: row.id,
+          conversationId: row.conversation_id,
+          modelId: row.model_id,
+          output: row.output,
+          createdAt: row.created_at,
+        };
+        acc[row.conversation_id]!.push(entry);
+        return acc;
+      }, {});
+    },
+    upsertModel(id: string, displayName: string, provider: string) {
+      const now = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO models (id, display_name, provider, updated_at)
+         VALUES (@id, @display_name, @provider, @updated_at)
+         ON CONFLICT(id) DO UPDATE SET
+            display_name = excluded.display_name,
+            provider = excluded.provider,
+            updated_at = excluded.updated_at`,
+      ).run({
+        id,
+        display_name: displayName,
+        provider,
+        updated_at: now,
+      });
+    },
+    createConversation(title: string, modelId: string) {
+      const now = new Date().toISOString();
+      const id = randomUUID();
+      db.prepare(
+        `INSERT INTO conversations (id, title, model_id, created_at, updated_at)
+         VALUES (@id, @title, @model_id, @created_at, @updated_at)`,
+      ).run({
+        id,
+        title,
+        model_id: modelId,
+        created_at: now,
+        updated_at: now,
+      });
+      return id;
+    },
+    insertMessage(message: Omit<WorkspaceMessage, "id" | "createdAt"> & { createdAt?: string }) {
+      const id = randomUUID();
+      const createdAt = message.createdAt ?? new Date().toISOString();
+      db.prepare(
+        `INSERT INTO messages (id, conversation_id, role, content, created_at)
+         VALUES (@id, @conversation_id, @role, @content, @created_at)`,
+      ).run({
+        id,
+        conversation_id: message.conversationId,
+        role: message.role,
+        content: message.content,
+        created_at: createdAt,
+      });
+      touchConversation(message.conversationId, createdAt);
+      return id;
+    },
+    insertThinkingRun(run: Omit<WorkspaceThinkingRun, "id" | "createdAt"> & { createdAt?: string }) {
+      const id = randomUUID();
+      const createdAt = run.createdAt ?? new Date().toISOString();
+      db.prepare(
+        `INSERT INTO thinking_runs (id, conversation_id, model_id, output, created_at)
+         VALUES (@id, @conversation_id, @model_id, @output, @created_at)`,
+      ).run({
+        id,
+        conversation_id: run.conversationId,
+        model_id: run.modelId,
+        output: run.output,
+        created_at: createdAt,
+      });
+      touchConversation(run.conversationId, createdAt);
+      return id;
+    },
+  };
+
+  function listMessages(conversationId: string): WorkspaceMessage[] {
+    const rows = db
+      .prepare(
+        `SELECT id, conversation_id, role, content, created_at FROM messages WHERE conversation_id = @conversationId ORDER BY created_at ASC`,
+      )
+      .all({ conversationId }) as Array<{
+      id: string;
+      conversation_id: string;
+      role: string;
+      content: string;
+      created_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      conversationId: row.conversation_id,
+      role: row.role as WorkspaceMessage["role"],
+      content: row.content,
+      createdAt: row.created_at,
+    }));
+  }
+
+  function touchConversation(conversationId: string, isoDate: string) {
+    db.prepare(
+      `UPDATE conversations SET updated_at = @updated_at WHERE id = @conversation_id`,
+    ).run({
+      updated_at: isoDate,
+      conversation_id: conversationId,
+    });
+  }
+}
+
+function ensureDirectory(directory: string) {
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+}

--- a/lib/model-store.ts
+++ b/lib/model-store.ts
@@ -1,0 +1,42 @@
+import type { WorkspaceModel } from "@/server/workspace-data";
+import { getDatabase } from "@/lib/database";
+
+const defaultModels: WorkspaceModel[] = [
+  {
+    id: "gpt-4o-mini",
+    displayName: "GPT-4o Mini",
+    provider: "openai",
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "gpt-4o",
+    displayName: "GPT-4o",
+    provider: "openai",
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "qwen-plus",
+    displayName: "Qwen Plus",
+    provider: "aliyun",
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+let hydrated = false;
+
+export async function getModelStore() {
+  const db = await getDatabase();
+
+  if (!hydrated) {
+    for (const model of defaultModels) {
+      db.upsertModel(model.id, model.displayName, model.provider);
+    }
+    hydrated = true;
+  }
+
+  return {
+    listModels(): WorkspaceModel[] {
+      return db.listModels();
+    },
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: ["better-sqlite3"],
+  },
+  transpilePackages: ["@tanstack/react-query"],
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "thinking-chat",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.45.0",
+    "better-sqlite3": "^9.4.0",
+    "classnames": "^2.5.1",
+    "dayjs": "^1.11.11",
+    "next": "^14.2.5",
+    "next-themes": "^0.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/server/orchestrator.ts
+++ b/server/orchestrator.ts
@@ -1,0 +1,110 @@
+import type { WorkspaceMessage } from "@/server/workspace-data";
+import { getDatabase } from "@/lib/database";
+import { fetchChatCompletion } from "@/server/platform";
+
+export type OrchestratorRequest = {
+  conversationId?: string;
+  messages: Array<Pick<WorkspaceMessage, "role" | "content">>;
+  settings: {
+    baseUrl?: string;
+    apiKey?: string;
+    model: string;
+    thinking?: {
+      enabled: boolean;
+      thinkingModel: string;
+      answerModel: string;
+      systemPrompt?: string;
+    };
+  };
+};
+
+export type OrchestratorResponse = {
+  conversationId: string;
+  message: WorkspaceMessage;
+  thinkingRun?: {
+    modelId: string;
+    output: string;
+  };
+};
+
+export async function orchestrateChat(
+  request: OrchestratorRequest,
+): Promise<OrchestratorResponse> {
+  const db = await getDatabase();
+  const conversationId =
+    request.conversationId ?? db.createConversation("New conversation", request.settings.model);
+
+  let thinkingOutput: string | null = null;
+
+  const latestUserMessage = [...request.messages]
+    .reverse()
+    .find((message) => message.role === "user");
+  if (latestUserMessage) {
+    db.insertMessage({
+      conversationId,
+      role: "user",
+      content: latestUserMessage.content,
+    });
+  }
+
+  if (request.settings.thinking?.enabled) {
+    const thinkingPrompt = request.settings.thinking.systemPrompt ??
+      "You are an expert reasoning assistant. Think through the user's request in detail and provide a plan.";
+    const thinkingResponse = await fetchChatCompletion({
+      baseUrl: request.settings.baseUrl,
+      apiKey: request.settings.apiKey,
+      model: request.settings.thinking.thinkingModel,
+      messages: [
+        { role: "system", content: thinkingPrompt },
+        ...request.messages,
+      ],
+    });
+    thinkingOutput = thinkingResponse.content;
+    db.insertThinkingRun({
+      conversationId,
+      modelId: request.settings.thinking.thinkingModel,
+      output: thinkingOutput,
+    });
+  }
+
+  const answerMessages = request.settings.thinking?.enabled && thinkingOutput
+    ? [
+        ...request.messages,
+        { role: "system", content: `Prior thinking:\n${thinkingOutput}` },
+      ]
+    : request.messages;
+
+  const completion = await fetchChatCompletion({
+    baseUrl: request.settings.baseUrl,
+    apiKey: request.settings.apiKey,
+    model: request.settings.thinking?.enabled
+      ? request.settings.thinking.answerModel
+      : request.settings.model,
+    messages: answerMessages,
+  });
+
+  const createdAt = new Date().toISOString();
+  const messageId = db.insertMessage({
+    conversationId,
+    role: "assistant",
+    content: completion.content,
+    createdAt,
+  });
+
+  return {
+    conversationId,
+    message: {
+      id: messageId,
+      conversationId,
+      role: "assistant",
+      content: completion.content,
+      createdAt,
+    },
+    thinkingRun: thinkingOutput
+      ? {
+          modelId: request.settings.thinking!.thinkingModel,
+          output: thinkingOutput,
+        }
+      : undefined,
+  };
+}

--- a/server/platform.ts
+++ b/server/platform.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const chatCompletionSchema = z.object({
+  content: z.string(),
+});
+
+type ChatCompletionRequest = {
+  baseUrl?: string;
+  apiKey?: string;
+  model: string;
+  messages: Array<{ role: string; content: string }>;
+};
+
+export async function fetchChatCompletion(
+  request: ChatCompletionRequest,
+): Promise<{ content: string }> {
+  // Placeholder: in development we simulate a response to keep the UI working offline.
+  // Integrators should replace this with real fetch() calls to the OpenAI-compatible endpoint.
+  const simulatedContent = `Model ${request.model} would respond to ${request.messages.length} message(s).`;
+  return chatCompletionSchema.parse({ content: simulatedContent });
+}

--- a/server/workspace-data.ts
+++ b/server/workspace-data.ts
@@ -1,0 +1,62 @@
+import { getDatabase } from "@/lib/database";
+import { getModelStore } from "@/lib/model-store";
+
+export type WorkspaceModel = {
+  id: string;
+  displayName: string;
+  provider: string;
+  updatedAt: string;
+};
+
+export type WorkspaceMessage = {
+  id: string;
+  conversationId: string;
+  role: "user" | "assistant" | "system" | "tool";
+  content: string;
+  createdAt: string;
+};
+
+export type WorkspaceConversation = {
+  id: string;
+  title: string;
+  modelId: string;
+  modelLabel: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: WorkspaceMessage[];
+};
+
+export type WorkspaceThinkingRun = {
+  id: string;
+  conversationId: string;
+  modelId: string;
+  output: string;
+  createdAt: string;
+};
+
+export type InitialWorkspaceData = {
+  models: WorkspaceModel[];
+  conversations: WorkspaceConversation[];
+  thinkingRuns: Record<string, WorkspaceThinkingRun[]>;
+};
+
+export async function fetchInitialWorkspaceData(): Promise<InitialWorkspaceData> {
+  const db = await getDatabase();
+  const modelStore = await getModelStore();
+
+  const models = modelStore.listModels();
+  const modelMap = new Map(models.map((model) => [model.id, model]));
+  const conversations = db
+    .listConversations()
+    .map((conversation) => ({
+      ...conversation,
+      modelLabel: modelMap.get(conversation.modelId)?.displayName ?? conversation.modelId,
+    }));
+  const thinkingRuns = db.listThinkingRuns();
+
+  return {
+    models,
+    conversations,
+    thinkingRuns,
+  };
+}

--- a/src/state/providers.tsx
+++ b/src/state/providers.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
+import { ReactNode, useState } from "react";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    </ThemeProvider>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,26 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        muted: "hsl(var(--muted))",
+        "muted-foreground": "hsl(var(--muted-foreground))",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@server/*": ["./server/*"]
+    },
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a Next.js + TypeScript project with Tailwind, React Query providers, and updated README
- add SQLite persistence layer for models, conversations, messages, and thinking runs with default model seeding
- stub API routes and workspace UI shell supporting thinking pipeline orchestration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e216754044832ca22f9b1b93ec1af1